### PR TITLE
fix: Added path-based linking fallback for environments that can't use pkgconfig

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,5 +6,7 @@ fn main() {
 
 #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd")))]
 fn main() {
-    system_deps::Config::new().probe().unwrap();
+    if system_deps::Config::new().probe().is_err() {
+        println!("cargo:rustc-link-lib=dylib=bsd");
+    }
 }


### PR DESCRIPTION
Fix for armhf cross compilation