### PR TITLE
On FreeBSD, use libc directly

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 fn main() {
-    println!("cargo:rustc-link-lib=util");
     println!("cargo:rerun-if-changed=build.rs");
 }
 


### PR DESCRIPTION
because it already defines the pidfile functions, and links to libutil.