### PR TITLE
Update nix dev dependency to 0.27.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ libbsd = "0.1.6"
 
 [dev-dependencies]
 tempfile = "3"
-nix = "^0.19"
+nix = {version = "0.27.0", features = ["process"] }


### PR DESCRIPTION
This resolves a cargo audit alert.  It also probably improves compile times since this version of Nix uses fine-grained feature flags.

RUSTSEC-2021-0119